### PR TITLE
Return false instead of 0 from parseBackticks

### DIFF
--- a/lib/inlines.js
+++ b/lib/inlines.js
@@ -148,7 +148,7 @@ var spnl = function() {
 var parseBackticks = function(block) {
     var ticks = this.match(reTicksHere);
     if (ticks === null) {
-        return 0;
+        return false;
     }
     var afterOpenTicks = this.pos;
     var matched;


### PR DESCRIPTION
The other return statements also return a boolean.