### PR TITLE
Remove unnecessary check for hrule in parseListMarker

### DIFF
--- a/lib/blocks.js
+++ b/lib/blocks.js
@@ -151,9 +151,6 @@ var parseListMarker = function(ln, offset, indent) {
                  delimiter: null,
                  padding: null,
                  markerOffset: indent };
-    if (rest.match(reHrule)) {
-        return null;
-    }
     if ((match = rest.match(reBulletListMarker))) {
         spaces_after_marker = match[1].length;
         data.type = 'Bullet';


### PR DESCRIPTION
By the time parseListMarker is called, the hrule block start was already
tried. In case it matches, no further block starts are tried. So the
later check is not necessary and can be removed.