### PR TITLE
Optimize checking for final spaces in parseNewline

### DIFF
--- a/lib/inlines.js
+++ b/lib/inlines.js
@@ -707,12 +707,10 @@ var parseNewline = function(block) {
     this.pos += 1; // assume we're at a \n
     // check previous node for trailing spaces
     var lastc = block._lastChild;
-    if (lastc && lastc.type === 'Text') {
-        var sps = reFinalSpace.exec(lastc._literal)[0].length;
-        if (sps > 0) {
-            lastc._literal = lastc._literal.replace(reFinalSpace, '');
-        }
-        block.appendChild(new Node(sps >= 2 ? 'Hardbreak' : 'Softbreak'));
+    if (lastc && lastc.type === 'Text' && lastc._literal[lastc._literal.length - 1] === ' ') {
+        var hardbreak = lastc._literal[lastc._literal.length - 2] === ' ';
+        lastc._literal = lastc._literal.replace(reFinalSpace, '');
+        block.appendChild(new Node(hardbreak ? 'Hardbreak' : 'Softbreak'));
     } else {
         block.appendChild(new Node('Softbreak'));
     }


### PR DESCRIPTION
This seems to yield a speed boost of about 5-10 % using `make bench`. I'd be interested if you can reproduce the results :).