### PR TITLE
Extract RE test results in scanDelims as local variables

### DIFF
--- a/lib/inlines.js
+++ b/lib/inlines.js
@@ -240,9 +240,7 @@ var scanDelims = function(cc) {
     var char_before, char_after, cc_after;
     var startpos = this.pos;
     var left_flanking, right_flanking, can_open, can_close;
-
-    char_before = this.pos === 0 ? '\n' :
-        this.subject.charAt(this.pos - 1);
+    var after_is_whitespace, after_is_punctuation, before_is_whitespace, before_is_punctuation;
 
     if (cc === C_SINGLEQUOTE || cc === C_DOUBLEQUOTE) {
         numdelims++;
@@ -254,6 +252,12 @@ var scanDelims = function(cc) {
         }
     }
 
+    if (numdelims == 0) {
+        return null;
+    }
+
+    char_before = startpos === 0 ? '\n' : this.subject.charAt(startpos - 1);
+
     cc_after = this.peek();
     if (cc_after === -1) {
         char_after = '\n';
@@ -261,21 +265,20 @@ var scanDelims = function(cc) {
         char_after = fromCodePoint(cc_after);
     }
 
-    left_flanking = numdelims > 0 &&
-            !(reWhitespaceChar.test(char_after)) &&
-            !(rePunctuation.test(char_after) &&
-             !(reWhitespaceChar.test(char_before)) &&
-             !(rePunctuation.test(char_before)));
-    right_flanking = numdelims > 0 &&
-            !(reWhitespaceChar.test(char_before)) &&
-            !(rePunctuation.test(char_before) &&
-              !(reWhitespaceChar.test(char_after)) &&
-              !(rePunctuation.test(char_after)));
+    after_is_whitespace = reWhitespaceChar.test(char_after);
+    after_is_punctuation = rePunctuation.test(char_after);
+    before_is_whitespace = reWhitespaceChar.test(char_before);
+    before_is_punctuation = rePunctuation.test(char_before);
+
+    left_flanking = !after_is_whitespace &&
+            !(after_is_punctuation && !before_is_whitespace && !before_is_punctuation);
+    right_flanking = !before_is_whitespace &&
+            !(before_is_punctuation && !after_is_whitespace && !after_is_punctuation);
     if (cc === C_UNDERSCORE) {
         can_open = left_flanking &&
-            (!right_flanking || rePunctuation.test(char_before));
+            (!right_flanking || before_is_punctuation);
         can_close = right_flanking &&
-            (!left_flanking || rePunctuation.test(char_after));
+            (!left_flanking || after_is_punctuation);
     } else {
         can_open = left_flanking;
         can_close = right_flanking;
@@ -289,13 +292,12 @@ var scanDelims = function(cc) {
 // Handle a delimiter marker for emphasis or a quote.
 var handleDelim = function(cc, block) {
     var res = this.scanDelims(cc);
+    if (!res) {
+        return false;
+    }
     var numdelims = res.numdelims;
     var startpos = this.pos;
     var contents;
-
-    if (numdelims === 0) {
-        return false;
-    }
 
     this.pos += numdelims;
     if (cc === C_SINGLEQUOTE) {


### PR DESCRIPTION
Also, abort earlier when no delims where found.

Couldn't determine a measurable performance impact, but code feels nicer that way.