### PR TITLE
add titles for anchoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,8 @@ will produce an XML representation of the AST:
 var writer = new commonmark.XmlRenderer({sourcepos: true});
 ```
 
+### AST node propeties
+
 The parser returns a Node.  The following public properties are defined
 (those marked "read-only" have only a getter, not a setter):
 
@@ -138,6 +140,8 @@ The parser returns a Node.  The following public properties are defined
 - `listStart`: a Number, the starting number of an ordered list.
 - `listDelimiter`: a String, either `)` or `.` for an ordered list.
 
+### AST node methods
+
 Nodes have the following public methods:
 
 - `appendChild(child)`:  Append a Node `child` to the end of the
@@ -150,6 +154,8 @@ Nodes have the following public methods:
 - `insertBefore(sibling)`: Insert a Node `sibling` before the Node.
 - `walker()`: Returns a NodeWalker that can be used to iterate through
   the Node tree rooted in the Node.
+
+### AST node‘s `walker` method
 
 The NodeWalker returned by `walker()` has two methods:
 


### PR DESCRIPTION
I’m writing documentation for helpers lib and found that I cannot give a link to readme’s section because there are no titles. I added them.