### PR TITLE
Don't consider images to be self-closing in the XML writer.

### DIFF
--- a/lib/xml.js
+++ b/lib/xml.js
@@ -76,7 +76,7 @@ var renderNodes = function(block) {
 
         container = node.isContainer;
         selfClosing = nodetype === 'HorizontalRule' || nodetype === 'Hardbreak' ||
-            nodetype === 'Softbreak' || nodetype === 'Image';
+            nodetype === 'Softbreak';
         unescapedContents = nodetype === 'Html' || nodetype === 'HtmlInline';
         tagname = toTagName(nodetype);
 


### PR DESCRIPTION
Image nodes in a CommonMark AST are containers, and as such the XML writer will always output a closing tag.

Clicking "AST" in [this dingus](http://spec.commonmark.org/dingus/?text=!%5B%5D(http%3A%2F%2Fexample.org)) shows the problem:

    <?xml version="1.0" encoding="UTF-8"?>
    <!DOCTYPE CommonMark SYSTEM "CommonMark.dtd">
    <document sourcepos="1:1-1:23">
      <paragraph sourcepos="1:1-1:23">
        <image destination="http://example.org" title="" />
        </image>
      </paragraph>
    </document>

The image tag is both self-closing (`/>`) and has a closing `</image>` tag.

Side note: I ran `make lint` as per [CONTRIBUTING](https://github.com/jgm/commonmark.js/blob/master/CONTRIBUTING.md), and there is indeed one error in `xml.js`. I did not fix it because it is unrelated to this change.