### PR TITLE
Allow literal (non-escaping) backslashes in link destinations

### DIFF
--- a/lib/inlines.js
+++ b/lib/inlines.js
@@ -32,7 +32,7 @@ var C_DOUBLEQUOTE = 34;
 var ESCAPABLE = common.ESCAPABLE;
 var ESCAPED_CHAR = '\\\\' + ESCAPABLE;
 var REG_CHAR = '[^\\\\()\\x00-\\x20]';
-var IN_PARENS_NOSP = '\\((' + REG_CHAR + '|' + ESCAPED_CHAR + ')*\\)';
+var IN_PARENS_NOSP = '\\((' + REG_CHAR + '|' + ESCAPED_CHAR + '|\\\\)*\\)';
 var TAGNAME = '[A-Za-z][A-Za-z0-9]*';
 var ATTRIBUTENAME = '[a-zA-Z_:][a-zA-Z0-9:._-]*';
 var UNQUOTEDVALUE = "[^\"'=<>`\\x00-\\x20]+";
@@ -66,7 +66,7 @@ var reLinkDestinationBraces = new RegExp(
     '^(?:[<](?:[^<>\\n\\\\\\x00]' + '|' + ESCAPED_CHAR + '|' + '\\\\)*[>])');
 
 var reLinkDestination = new RegExp(
-    '^(?:' + REG_CHAR + '+|' + ESCAPED_CHAR + '|' + IN_PARENS_NOSP + ')*');
+    '^(?:' + REG_CHAR + '+|' + ESCAPED_CHAR + '|\\\\|' + IN_PARENS_NOSP + ')*');
 
 var reEscapable = new RegExp('^' + ESCAPABLE);
 


### PR DESCRIPTION
Per 6.1,

> Backslashes before other characters are treated as literal backslashes

The definition of a link destination does not preclude such backslashes from appearing (and in fact it already works if the link is inside angle brackets).

[Dingus link of the cases this fixes](http://spec.commonmark.org/dingus/?text=%5Bfoo%5D(%5Cx)%0A%0A%5Bfoo%5D((%5Cx))%0A%0A%5Bfoo%5D%5B1%5D%0A%0A%5Bfoo%5D%5B2%5D%0A%0A%5B1%5D%3A%20%5Cx%0A%5B2%5D%3A%20(%5Cx)%0A) (all four should be links).

This probably warrants a test, but I'm not sure whether you want such cases as examples in the spec or in a different place.

As far as I can tell from looking at [the code](https://github.com/jgm/cmark/blob/1acd161b2f25e71a40c903ea8997a6ee2f4694d2/src/scanners.re), cmark requires the same change; unfortunately I don't currently have the setup ready to work on and test it.