### PR TITLE
Fix link reference definition edge case.

### DIFF
--- a/lib/inlines.js
+++ b/lib/inlines.js
@@ -793,7 +793,23 @@ var parseReference = function(s, refmap) {
     }
 
     // make sure we're at line end:
+    var atLineEnd = true;
     if (this.match(reSpaceAtEndOfLine) === null) {
+        if (title === '') {
+            atLineEnd = false;
+        } else {
+            // the potential title we found is not at the line end,
+            // but it could still be a legal link reference if we
+            // discard the title
+            title = '';
+            // rewind before spaces
+            this.pos = beforetitle;
+            // and instead check if the link URL is at the line end
+            atLineEnd = this.match(reSpaceAtEndOfLine) !== null;
+        }
+    }
+
+    if (!atLineEnd) {
         this.pos = startpos;
         return 0;
     }


### PR DESCRIPTION
If the reference seems to have a valid title that however does not go until the end of the line, check if the reference becomes valid when discarding the title.

[Dingus link](http://spec.commonmark.org/dingus/?text=%5Bfoo%5D%3A%20%2Furl%0A%22title%22%20ok); source:

```markdown
[foo]: /url
"title" ok
```

Expected output:

```html
<p>&quot;title&quot; ok</p>
```

Actual output:

```html
<p>[foo]: /url
&quot;title&quot; ok</p>
```