### PR TITLE
Switch to "smart" hyphen replacement (closes #56)

### DIFF
--- a/lib/inlines.js
+++ b/lib/inlines.js
@@ -8,6 +8,7 @@ var normalizeURI = common.normalizeURI;
 var unescapeString = common.unescapeString;
 var fromCodePoint = require('./from-code-point.js');
 var decodeHTML = require('entities').decodeHTML;
+require('string.prototype.repeat'); // Polyfill for String.prototype.repeat
 
 // Constants for character codes:
 
@@ -78,7 +79,7 @@ var reTicksHere = /^`+/;
 
 var reEllipses = /\.\.\./g;
 
-var reDash = /---?/g;
+var reDash = /--+/g;
 
 var reEmailAutolink = /^<([a-zA-Z0-9.!#$%&'*+\/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*)>/;
 
@@ -721,7 +722,20 @@ var parseString = function(block) {
             block.appendChild(text(
                 m.replace(reEllipses, "\u2026")
                     .replace(reDash, function(chars) {
-                        return (chars.length === 3) ? "\u2014" : "\u2013";
+                        var enCount = 0;
+                        var emCount = 0;
+                        if (chars.length % 3 === 0) { // If divisible by 3, use all em dashes
+                            emCount = chars.length / 3;
+                        } else if (chars.length % 2 === 0) { // If divisible by 2, use all en dashes
+                            enCount = chars.length / 2;
+                        } else if (chars.length % 3 === 2) { // If 2 extra dashes, use en dash for last 2; em dashes for rest
+                            emCount = Math.floor(chars.length / 3);
+                            enCount = 1;
+                        } else { // Use en dashes for last 4 hyphens; em dashes for rest
+                            emCount = Math.floor((chars.length - 4) / 3);
+                            enCount = 2;
+                        }
+                        return "\u2014".repeat(emCount) + "\u2013".repeat(enCount);
                     })));
         } else {
             block.appendChild(text(m));

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
   "scripts": { "test": "node ./test/test.js" },
   "dependencies": {
     "entities": "~ 1.1.1",
-    "mdurl": "~ 1.0.0"
+    "mdurl": "~ 1.0.0",
+    "string.prototype.repeat": "^0.2.0"
   },
   "directories": {
       "lib": "./lib"

--- a/test/smart_punct.txt
+++ b/test/smart_punct.txt
@@ -65,10 +65,14 @@ This isn't either.</p>
 
 .
 Some dashes:  one---two ---
-three---four --- five.
+three---four --- five ----
+six ----- seven ------
+eight ------- nine ----------.
 .
 <p>Some dashes:  one—two —
-three—four — five.</p>
+three—four — five ––
+six —– seven ——
+eight —–– nine –––––.</p>
 .
 
 .


### PR DESCRIPTION
- Adds tests for longer sequences of hyphens
- Changes behavior as follows:

    ```
    Current: ---------- => --- --- --- -  => ———-
        New: ---------- => -- -- -- -- -- => –––––

    Current: ------- => --- --- - => ——-
        New: ------- => --- -- -- => —––

    Current: ---- => --- - => —-
        New: ---- => -- -- => ––
    ```
