### PR TITLE
Fix replacement of multiple apostrophes in the same paragraph.

### DIFF
--- a/lib/inlines.js
+++ b/lib/inlines.js
@@ -265,6 +265,9 @@ var scanDelims = function(cc) {
             (!right_flanking || before_is_punctuation);
         can_close = right_flanking &&
             (!left_flanking || after_is_punctuation);
+    } else if (cc === C_SINGLEQUOTE) {
+        can_open = left_flanking && !right_flanking;
+        can_close = right_flanking;
     } else {
         can_open = left_flanking;
         can_close = right_flanking;

--- a/test/smart_punct.txt
+++ b/test/smart_punct.txt
@@ -58,6 +58,14 @@ by the single quote before `jolly`:
 <p>’tis the season to be ‘jolly’</p>
 .
 
+Multiple apostrophes should not be marked as open/closing quotes.
+
+.
+'We'll use Jane's boat and John's truck,' Jenna said.
+.
+<p>‘We’ll use Jane’s boat and John’s truck,’ Jenna said.</p>
+.
+
 An unmatched double quote will be interpreted as a
 left double quote, to facilitate this style:
 


### PR DESCRIPTION
```
'We'll use Jane's boat and John's truck,' Jenna said.
```

...currently outputs backwards apostrophes in cases with multiple apostrophes per paragraph:

```
<p>‘We‘ll use Jane‘s boat and John‘s truck,’ Jenna said.</p>
```

This fix makes changes the output to:

```
<p>‘We’ll use Jane’s boat and John’s truck,’ Jenna said.</p>
```

A little hard to tell on GitHub, but if you change the font to one that differentiates quotes more, you'll be able to tell.