### PR TITLE
Update .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,4 @@
-commonmark.js
-*.tgz
-index.html
+*
+!bin/*
+!dist/*
+!lib/*


### PR DESCRIPTION
When publishing a npm module the entire working directory is published unless excluded using `.npmignore`.   In this case it means installing commonmark includes tests, benchmarks, bower_components, documentation (which itself includes bootstrap, jquery, and lodash), and many temporary files that I am certain you never intended to publish. The current commonmark tgz downloaded from npm is 1.3 Mb (https://registry.npmjs.org/commonmark/-/commonmark-0.22.0.tgz).  With this change only package.json, LICENSE, README.md and the code files will be packaged. You can test what files get packaged by executing npm pack.  Should be ~120k after this change.