### PR TITLE
Test on node.js 5.x and 4.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: node_js
 node_js:
+  - "5"
+  - "4"
   - "0.12"
   - "0.10"
-  - iojs
 sudo: false


### PR DESCRIPTION
Remove testing on iojs, since it has been merged back in with node.js