### PR TITLE
Remove unused variable markerStartCol

### DIFF
--- a/lib/blocks.js
+++ b/lib/blocks.js
@@ -142,7 +142,6 @@ var parseListMarker = function(parser) {
     var rest = parser.currentLine.slice(parser.nextNonspace);
     var match;
     var nextc;
-    var markerStartCol;
     var spacesStartCol;
     var spacesStartOffset;
     var data = { type: null,
@@ -171,7 +170,6 @@ var parseListMarker = function(parser) {
 
     // we've got a match! advance offset and calculate padding
     parser.advanceNextNonspace(); // to start of marker
-    markerStartCol = parser.column;
     parser.advanceOffset(match[0].length, true); // to end of marker
     spacesStartCol = parser.column;
     spacesStartOffset = parser.offset;


### PR DESCRIPTION
I don't know if this is there for a reason, but `markerStartCol` isn't being used anywhere
and can be removed.

It was introduced just recently in commit 3ffa89306c1be42fe3a6071b4007b1dbca82505c