### PR TITLE
Better ECMAScript 5 style inheritance.

### DIFF
--- a/lib/render/html.js
+++ b/lib/render/html.js
@@ -264,7 +264,7 @@ function attrs (node) {
 }
 
 // quick browser-compatible inheritance
-HtmlRenderer.prototype = new Renderer();
+HtmlRenderer.prototype = Object.create(Renderer.prototype);
 
 HtmlRenderer.prototype.text = text;
 HtmlRenderer.prototype.html_inline = html_inline;


### PR DESCRIPTION
Tiny change, tests passing. Likely won't affect performance although it does prevent a call to the `Renderer` constructor when assigning to `prototype`.

I don't know what your browser targets are but this should be fine with all modern browsers (IE9+).