### PR TITLE
Simplify CDATA regex

### DIFF
--- a/lib/common.js
+++ b/lib/common.js
@@ -22,7 +22,7 @@ var CLOSETAG = "</" + TAGNAME + "\\s*[>]";
 var HTMLCOMMENT = "<!---->|<!--(?:-?[^>-])(?:-?[^-])*-->";
 var PROCESSINGINSTRUCTION = "[<][?].*?[?][>]";
 var DECLARATION = "<![A-Z]+" + "\\s+[^>]*>";
-var CDATA = "<!\\[CDATA\\[[\\s\\S]*?\\]\\]>";
+var CDATA = "<!\\[CDATA\\[.*?\\]\\]>";
 var HTMLTAG = "(?:" + OPENTAG + "|" + CLOSETAG + "|" + HTMLCOMMENT + "|" +
         PROCESSINGINSTRUCTION + "|" + DECLARATION + "|" + CDATA + ")";
 var reHtmlTag = new RegExp('^' + HTMLTAG, 'i');


### PR DESCRIPTION
`[\s\S]` should be the same as `.`.