### PR TITLE
Add link references to the document node as refs list

### DIFF
--- a/lib/blocks.js
+++ b/lib/blocks.js
@@ -398,7 +398,7 @@ var blocks = {
             // try parsing the beginning as link reference definitions:
             while (peek(block._string_content, 0) === C_OPEN_BRACKET &&
                    (pos =
-                    parser.inlineParser.parseReference(block._string_content,
+                    parser.inlineParser.parseReference(block, block._string_content,
                                                        parser.refmap))) {
                 block._string_content = block._string_content.slice(pos);
                 hasReferenceDefs = true;

--- a/lib/blocks.js
+++ b/lib/blocks.js
@@ -404,7 +404,7 @@ var blocks = {
                 hasReferenceDefs = true;
 
                 // add link references to document node as a refs list
-                if(block._lastChild && block._lastChild._link) {
+                if (block._lastChild && block._lastChild._linkType === 'ref') {
                   parser.doc.refs = parser.doc.refs || [];
                   parser.doc.refs.push(block._lastChild);
                   block._lastChild.unlink();

--- a/lib/blocks.js
+++ b/lib/blocks.js
@@ -402,6 +402,13 @@ var blocks = {
                                                        parser.refmap))) {
                 block._string_content = block._string_content.slice(pos);
                 hasReferenceDefs = true;
+
+                // add link references to document node as a refs list
+                if(block._lastChild && block._lastChild._link) {
+                  parser.doc.refs = parser.doc.refs || [];
+                  parser.doc.refs.push(block._lastChild);
+                  block._lastChild.unlink();
+                }
             }
             if (hasReferenceDefs && isBlank(block._string_content)) {
                 block.unlink();

--- a/lib/inlines.js
+++ b/lib/inlines.js
@@ -826,7 +826,7 @@ var parseReference = function(block, s, refmap) {
         refmap[normlabel] = { destination: dest, title: title };
         // store a link ref node so the parser can add it to the document
         var node = new Node('ref');
-        node._link = refmap[normlabel];
+        node._link = { destination: dest, title: title, label: normlabel};
         block.appendChild(node);
     }
     return this.pos - startpos;

--- a/lib/inlines.js
+++ b/lib/inlines.js
@@ -824,9 +824,10 @@ var parseReference = function(block, s, refmap) {
 
     if (!refmap[normlabel]) {
         refmap[normlabel] = { destination: dest, title: title };
-        //console.dir('creating linkref');
-        // WARN: no source_pos yet
-        var node = new Node('link_reference');
+        // store a link ref node so the parser can add it to the document
+        var node = new Node('ref');
+        node._link = refmap[normlabel];
+        block.appendChild(node);
     }
     return this.pos - startpos;
 };

--- a/lib/inlines.js
+++ b/lib/inlines.js
@@ -829,7 +829,6 @@ var parseReference = function(block, s, refmap) {
         node._linkType = 'ref';
         node._destination = dest;
         node._title = title;
-        node.appendChild(text(dest));
         block.appendChild(node);
     }
     return this.pos - startpos;

--- a/lib/inlines.js
+++ b/lib/inlines.js
@@ -750,7 +750,7 @@ var parseNewline = function(block) {
 };
 
 // Attempt to parse a link reference, modifying refmap.
-var parseReference = function(s, refmap) {
+var parseReference = function(block, s, refmap) {
     this.subject = s;
     this.pos = 0;
     var rawlabel;
@@ -824,6 +824,9 @@ var parseReference = function(s, refmap) {
 
     if (!refmap[normlabel]) {
         refmap[normlabel] = { destination: dest, title: title };
+        //console.dir('creating linkref');
+        // WARN: no source_pos yet
+        var node = new Node('link_reference');
     }
     return this.pos - startpos;
 };

--- a/lib/inlines.js
+++ b/lib/inlines.js
@@ -825,8 +825,11 @@ var parseReference = function(block, s, refmap) {
     if (!refmap[normlabel]) {
         refmap[normlabel] = { destination: dest, title: title };
         // store a link ref node so the parser can add it to the document
-        var node = new Node('ref');
-        node._link = { destination: dest, title: title, label: normlabel};
+        var node = new Node('link');
+        node._linkType = 'ref';
+        node._destination = dest;
+        node._title = title;
+        node.appendChild(text(dest));
         block.appendChild(node);
     }
     return this.pos - startpos;

--- a/lib/inlines.js
+++ b/lib/inlines.js
@@ -827,6 +827,7 @@ var parseReference = function(block, s, refmap) {
         // store a link ref node so the parser can add it to the document
         var node = new Node('link');
         node._linkType = 'ref';
+        node._label = normlabel;
         node._destination = dest;
         node._title = title;
         block.appendChild(node);


### PR DESCRIPTION
These commits preserve link references in the document node as a `refs` array, each entry is a node with a `ref` type that has an `_link` object.

The `_link` object contains `destination` and `title` as parsed by `parseReference()`.

Note that this *does not* maintain the source position for the parsed link references (however based on previous discussion) this was deemed not essential to exposing link references.

Tests continue to pass, not too sure of which is the best benchmark to run for this change but I think these changes are unlikely to impact performance dramatically.