### PR TITLE
Expose read-write accessors.

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -181,6 +181,21 @@ Object.defineProperty(proto, 'onExit', {
     set: function(s) { this._onExit = s; }
 });
 
+Object.defineProperty(proto, 'lastLineBlank', {
+    get: function() { return this._lastLineBlank; },
+    set: function(val) { this._lastLineBlank = val; }
+});
+
+Object.defineProperty(proto, 'htmlBlockType', {
+    get: function() { return this._htmlBlockType; },
+    set: function(val) { this._htmlBlockType = val; }
+});
+
+Object.defineProperty(proto, 'data', {
+    get: function() { return this._data; },
+    set: function(val) { this._data = val; }
+});
+
 Node.prototype.appendChild = function(child) {
     child.unlink();
     child._parent = this;


### PR DESCRIPTION
For `lastLineBlank`, `htmlBlockType` and a `data` property which allows AST
consumers to associate arbitrary data with an AST node.