### PR TITLE
Support _htmlBlockType for html_inline.

### DIFF
--- a/lib/blocks.js
+++ b/lib/blocks.js
@@ -16,16 +16,7 @@ var C_OPEN_BRACKET = 91;
 
 var InlineParser = require('./inlines');
 
-var reHtmlBlockOpen = [
-   /./, // dummy for 0
-   /^<(?:script|pre|style)(?:\s|>|$)/i,
-   /^<!--/,
-   /^<[?]/,
-   /^<![A-Z]/,
-   /^<!\[CDATA\[/,
-   /^<[/]?(?:address|article|aside|base|basefont|blockquote|body|caption|center|col|colgroup|dd|details|dialog|dir|div|dl|dt|fieldset|figcaption|figure|footer|form|frame|frameset|h1|head|header|hr|html|iframe|legend|li|link|main|menu|menuitem|meta|nav|noframes|ol|optgroup|option|p|param|section|source|title|summary|table|tbody|td|tfoot|th|thead|title|tr|track|ul)(?:\s|[/]?[>]|$)/i,
-    new RegExp('^(?:' + OPENTAG + '|' + CLOSETAG + ')\s*$', 'i')
-];
+var reHtmlBlockOpen = require('./common').reHtmlBlockOpen;
 
 var reHtmlBlockClose = [
    /./, // dummy for 0

--- a/lib/common.js
+++ b/lib/common.js
@@ -27,6 +27,17 @@ var HTMLTAG = "(?:" + OPENTAG + "|" + CLOSETAG + "|" + HTMLCOMMENT + "|" +
         PROCESSINGINSTRUCTION + "|" + DECLARATION + "|" + CDATA + ")";
 var reHtmlTag = new RegExp('^' + HTMLTAG, 'i');
 
+var reHtmlBlockOpen = [
+   /./, // dummy for 0
+   /^<(?:script|pre|style)(?:\s|>|$)/i,
+   /^<!--/,
+   /^<[?]/,
+   /^<![A-Z]/,
+   /^<!\[CDATA\[/,
+   /^<[/]?(?:address|article|aside|base|basefont|blockquote|body|caption|center|col|colgroup|dd|details|dialog|dir|div|dl|dt|fieldset|figcaption|figure|footer|form|frame|frameset|h1|head|header|hr|html|iframe|legend|li|link|main|menu|menuitem|meta|nav|noframes|ol|optgroup|option|p|param|section|source|title|summary|table|tbody|td|tfoot|th|thead|title|tr|track|ul)(?:\s|[/]?[>]|$)/i,
+    new RegExp('^(?:' + OPENTAG + '|' + CLOSETAG + ')\s*$', 'i')
+];
+
 var reBackslashOrAmp = /[\\&]/;
 
 var ESCAPABLE = '[!"#$%&\'()*+,./:;<=>?@[\\\\\\]^_`{|}~-]';
@@ -96,6 +107,7 @@ module.exports = { unescapeString: unescapeString,
                    normalizeURI: normalizeURI,
                    escapeXml: escapeXml,
                    reHtmlTag: reHtmlTag,
+                   reHtmlBlockOpen: reHtmlBlockOpen,
                    OPENTAG: OPENTAG,
                    CLOSETAG: CLOSETAG,
                    ENTITY: ENTITY,

--- a/lib/inlines.js
+++ b/lib/inlines.js
@@ -10,6 +10,8 @@ var fromCodePoint = require('./from-code-point.js');
 var decodeHTML = require('entities').decodeHTML;
 require('string.prototype.repeat'); // Polyfill for String.prototype.repeat
 
+var reHtmlBlockOpen = require('./common').reHtmlBlockOpen;
+
 // Constants for character codes:
 
 var C_NEWLINE = 10;
@@ -213,6 +215,15 @@ var parseHtmlTag = function(block) {
         var node = new Node('html_inline');
         node._literal = m;
         block.appendChild(node);
+
+        var blockType;
+        for (blockType = 1; blockType <= 7; blockType++) {
+            if(reHtmlBlockOpen[blockType].test(m) && blockType < 7) {
+              node._htmlBlockType = blockType;
+              break;
+            }
+        }
+
         return true;
     }
 };


### PR DESCRIPTION
Add support for the _htmlBlockType property on inline HTML elements;
this allows AST consumers to be able to know ahead of time the type for
inline HTML elements which is useful when parsing processing
instructions or comments.

Moved the reHtmlBlockOpen RegExp to the common module so that it may be
shared between the inline and block parsers.