### PR TITLE
remove unnecessary check

### DIFF
--- a/lib/blocks.js
+++ b/lib/blocks.js
@@ -588,7 +588,7 @@ var advanceOffset = function(count, columns) {
                 charsToAdvance = charsToTab > count ? count : charsToTab;
                 this.column += charsToAdvance;
                 this.offset += this.partiallyConsumedTab ? 0 : 1;
-                count -= (columns ? charsToAdvance : 1);
+                count -= charsToAdvance;
             } else {
                 this.partiallyConsumedTab = false;
                 this.column += charsToTab;


### PR DESCRIPTION
It looks like `columns` is always true in this block, so there's no need to check it during the assignment to `count`.