### PR TITLE
Simplify and optimize brackets processing (links/images)

### DIFF
--- a/lib/inlines.js
+++ b/lib/inlines.js
@@ -306,8 +306,7 @@ var handleDelim = function(cc, block) {
                         previous: this.delimiters,
                         next: null,
                         can_open: res.can_open,
-                        can_close: res.can_close,
-                        active: true };
+                        can_close: res.can_close };
     if (this.delimiters.previous !== null) {
         this.delimiters.previous.next = this.delimiters;
     }
@@ -357,10 +356,7 @@ var processEmphasis = function(stack_bottom) {
     // move forward, looking for closers, and handling each
     while (closer !== null) {
         var closercc = closer.cc;
-        if (!(closer.can_close && (closercc === C_UNDERSCORE ||
-                                   closercc === C_ASTERISK ||
-                                   closercc === C_SINGLEQUOTE ||
-                                   closercc === C_DOUBLEQUOTE))) {
+        if (!closer.can_close) {
             closer = closer.next;
         } else {
             // found emphasis closer. now look back for first matching opener:
@@ -513,21 +509,8 @@ var parseOpenBracket = function(block) {
     block.appendChild(node);
 
     // Add entry to stack for this opener
-    this.delimiters = { cc: C_OPEN_BRACKET,
-                        numdelims: 1,
-                        node: node,
-                        previous: this.delimiters,
-                        next: null,
-                        can_open: true,
-                        can_close: false,
-                        index: startpos,
-                        active: true };
-    if (this.delimiters.previous !== null) {
-        this.delimiters.previous.next = this.delimiters;
-    }
-
+    this.addBracket(node, startpos, false);
     return true;
-
 };
 
 // IF next character is [, and ! delimiter to delimiter stack and
@@ -542,18 +525,7 @@ var parseBang = function(block) {
         block.appendChild(node);
 
         // Add entry to stack for this opener
-        this.delimiters = { cc: C_BANG,
-                            numdelims: 1,
-                            node: node,
-                            previous: this.delimiters,
-                            next: null,
-                            can_open: true,
-                            can_close: false,
-                            index: startpos + 1,
-                            active: true };
-        if (this.delimiters.previous !== null) {
-            this.delimiters.previous.next = this.delimiters;
-        }
+        this.addBracket(node, startpos + 1, true);
     } else {
         block.appendChild(text('!'));
     }
@@ -576,15 +548,8 @@ var parseCloseBracket = function(block) {
     this.pos += 1;
     startpos = this.pos;
 
-    // look through stack of delimiters for a [ or ![
-    opener = this.delimiters;
-
-    while (opener !== null) {
-        if (opener.cc === C_OPEN_BRACKET || opener.cc === C_BANG) {
-            break;
-        }
-        opener = opener.previous;
-    }
+    // get last [ or ![
+    opener = this.brackets;
 
     if (opener === null) {
         // no matched opener, just return a literal
@@ -595,13 +560,13 @@ var parseCloseBracket = function(block) {
     if (!opener.active) {
         // no matched opener, just return a literal
         block.appendChild(text(']'));
-        // take opener off emphasis stack
-        this.removeDelimiter(opener);
+        // take opener off brackets stack
+        this.removeBracket();
         return true;
     }
 
     // If we got here, open is a potential opener
-    is_image = opener.cc === C_BANG;
+    is_image = opener.image;
 
     // Check to see if we have a link/image
 
@@ -625,23 +590,26 @@ var parseCloseBracket = function(block) {
         var savepos = this.pos;
         var beforelabel = this.pos;
         var n = this.parseLinkLabel();
-        if (n === 0 || n === 2) {
-            // empty or missing second label
-            reflabel = this.subject.slice(opener.index, startpos);
-        } else {
+        if (n > 2) {
             reflabel = this.subject.slice(beforelabel, beforelabel + n);
+        } else if (!opener.bracketAfter) {
+            // Empty or missing second label means to use the first label as the reference.
+            // The reference must not contain a bracket. If we know there's a bracket, we don't even bother checking it.
+            reflabel = this.subject.slice(opener.index, startpos);
         }
         if (n === 0) {
             // If shortcut reference link, rewind before spaces we skipped.
             this.pos = savepos;
         }
 
-        // lookup rawlabel in refmap
-        var link = this.refmap[normalizeReference(reflabel)];
-        if (link) {
-            dest = link.destination;
-            title = link.title;
-            matched = true;
+        if (reflabel) {
+            // lookup rawlabel in refmap
+            var link = this.refmap[normalizeReference(reflabel)];
+            if (link) {
+                dest = link.destination;
+                title = link.title;
+                matched = true;
+            }
         }
     }
 
@@ -659,17 +627,17 @@ var parseCloseBracket = function(block) {
             tmp = next;
         }
         block.appendChild(node);
-        this.processEmphasis(opener.previous);
-
+        this.processEmphasis(opener.previousDelimiter);
+        this.removeBracket();
         opener.node.unlink();
 
-        // processEmphasis will remove this and later delimiters.
+        // We remove this bracket and processEmphasis will remove later delimiters.
         // Now, for a link, we also deactivate earlier link openers.
         // (no links in links)
         if (!is_image) {
-          opener = this.delimiters;
+          opener = this.brackets;
           while (opener !== null) {
-            if (opener.cc === C_OPEN_BRACKET) {
+            if (!opener.image) {
                 opener.active = false; // deactivate this opener
             }
             opener = opener.previous;
@@ -680,12 +648,28 @@ var parseCloseBracket = function(block) {
 
     } else { // no match
 
-        this.removeDelimiter(opener);  // remove this opener from stack
+        this.removeBracket();  // remove this opener from stack
         this.pos = startpos;
         block.appendChild(text(']'));
         return true;
     }
 
+};
+
+var addBracket = function(node, index, image) {
+    if (this.brackets !== null) {
+        this.brackets.bracketAfter = true;
+    }
+    this.brackets = { node: node,
+                      previous: this.brackets,
+                      previousDelimiter: this.delimiters,
+                      index: index,
+                      image: image,
+                      active: true };
+};
+
+var removeBracket = function() {
+    this.brackets = this.brackets.previous;
 };
 
 // Attempt to parse an entity.
@@ -888,6 +872,7 @@ var parseInlines = function(block) {
     this.subject = block._string_content.trim();
     this.pos = 0;
     this.delimiters = null;
+    this.brackets = null;
     while (this.parseInline(block)) {
     }
     block._string_content = null; // allow raw string to be garbage collected
@@ -899,6 +884,7 @@ function InlineParser(options){
     return {
         subject: '',
         delimiters: null,  // used by handleDelim method
+        brackets: null,
         pos: 0,
         refmap: {},
         match: match,
@@ -914,8 +900,10 @@ function InlineParser(options){
         parseLinkDestination: parseLinkDestination,
         parseLinkLabel: parseLinkLabel,
         parseOpenBracket: parseOpenBracket,
-        parseCloseBracket: parseCloseBracket,
         parseBang: parseBang,
+        parseCloseBracket: parseCloseBracket,
+        addBracket: addBracket,
+        removeBracket: removeBracket,
         parseEntity: parseEntity,
         parseString: parseString,
         parseNewline: parseNewline,


### PR DESCRIPTION
The key insight for the simplification is that we don't need to keep the
brackets in the same stack as the other delimiters. All we need to know
is which delimiter came before the bracket, so that we can process the
emphasis in the image/link text.

This removes the need to loop to find the last opening bracket and also
removes the need to skip over brackets in processEmphasis.

In addition to that, we can skip the slice and reference lookup for
collapsed/shortcut reference links if we know that it contains a
bracket.

Together, these changes make the "nested brackets 10000 deep"
pathological case go from 400 ms to 20 ms.

Before:

> nested brackets 1000 deep ✓
>   elapsed time: 6.342ms
> nested brackets 10000 deep ✓
>   elapsed time: 402.198ms

After:

> nested brackets 1000 deep ✓
>   elapsed time: 0.824ms
> nested brackets 10000 deep ✓
>   elapsed time: 18.805ms