### PR TITLE
Expose potentiallyUnsafe function in HtmlRender prototype

### DIFF
--- a/lib/render/html.js
+++ b/lib/render/html.js
@@ -8,7 +8,7 @@ var reHtmlTag = /\<[^>]*\>/;
 var reUnsafeProtocol = /^javascript:|vbscript:|file:|data:/i;
 var reSafeDataProtocol = /^data:image\/(?:png|gif|jpeg|webp)/i;
 
-var potentiallyUnsafe = function(url) {
+function potentiallyUnsafe(url) {
     return reUnsafeProtocol.test(url) &&
         !reSafeDataProtocol.test(url);
 };
@@ -65,7 +65,7 @@ function linebreak() {
 function link(node, entering) {
   var attrs = this.attrs(node);
   if (entering) {
-      if (!(this.options.safe && potentiallyUnsafe(node.destination))) {
+      if (!(this.options.safe && this.potentiallyUnsafe(node.destination))) {
           attrs.push(['href', esc(node.destination, true)]);
       }
       if (node.title) {
@@ -81,7 +81,7 @@ function image(node, entering) {
   if (entering) {
       if (this.disableTags === 0) {
           if (this.options.safe &&
-               potentiallyUnsafe(node.destination)) {
+               this.potentiallyUnsafe(node.destination)) {
               this.lit('<img src="" alt="');
           } else {
               this.lit('<img src="' + esc(node.destination, true) +
@@ -289,5 +289,8 @@ HtmlRenderer.prototype.custom_block = custom_block;
 HtmlRenderer.prototype.out = out;
 HtmlRenderer.prototype.tag = tag;
 HtmlRenderer.prototype.attrs = attrs;
+
+HtmlRenderer.prototype.potentiallyUnsafe = potentiallyUnsafe;
+
 
 module.exports = HtmlRenderer;


### PR DESCRIPTION
When overriding the HtmlRender.link function it would be useful to be able to re-use the internal function potentiallyUnsafe().  I realise that this somewhat conflicts with @nicojs pull request.