### PR TITLE
Fix not existing property usage.

### DIFF
--- a/lib/blocks.js
+++ b/lib/blocks.js
@@ -593,7 +593,7 @@ var advanceOffset = function(count, columns) {
                 this.partiallyConsumedTab = false;
                 this.column += charsToTab;
                 this.offset += 1;
-                this.count -= 1;
+                count -= 1;
             }
         } else {
             this.partiallyConsumedTab = false;


### PR DESCRIPTION
I found probably a copy-paste error. 
`this.count` on `Parser` object is used only in one place. I think argument `count` was meant.
This doesn't affect test results, but could lead to potential problems in future.
