### PR TITLE
Remove unused write-only variable.

### DIFF
--- a/lib/blocks.js
+++ b/lib/blocks.js
@@ -576,7 +576,6 @@ var blockStarts = [
 ];
 
 var advanceOffset = function(count, columns) {
-    var cols = 0;
     var currentLine = this.currentLine;
     var charsToTab, charsToAdvance;
     var c;
@@ -597,7 +596,6 @@ var advanceOffset = function(count, columns) {
             }
         } else {
             this.partiallyConsumedTab = false;
-            cols += 1;
             this.offset += 1;
             this.column += 1; // assume ascii; block starts are ascii
             count -= 1;


### PR DESCRIPTION
Variable `cols` is used for incrementing, but the result is never used.