### PR TITLE
Make an distinction between Unicode whitespace and regular whitespace

### DIFF
--- a/lib/inlines.js
+++ b/lib/inlines.js
@@ -71,9 +71,13 @@ var reAutolink = /^<[A-Za-z][A-Za-z0-9.+-]{1,31}:[^<>\x00-\x20]*>/i;
 
 var reSpnl = /^ *(?:\n *)?/;
 
-var reWhitespaceChar = /^\s/;
+var reWhitespaceChar = /^[ \t\n\x0b\x0c\x0d]/;
 
-var reWhitespace = /\s+/g;
+var reWhitespace = /[ \t\n\x0b\x0c\x0d]+/g;
+
+var reUnicodeWhitespaceChar = /^\s/;
+
+var reUnicodeWhitespace = /\s+/g;
 
 var reFinalSpace = / *$/;
 
@@ -251,9 +255,9 @@ var scanDelims = function(cc) {
         char_after = fromCodePoint(cc_after);
     }
 
-    after_is_whitespace = reWhitespaceChar.test(char_after);
+    after_is_whitespace = reUnicodeWhitespaceChar.test(char_after);
     after_is_punctuation = rePunctuation.test(char_after);
-    before_is_whitespace = reWhitespaceChar.test(char_before);
+    before_is_whitespace = reUnicodeWhitespaceChar.test(char_before);
     before_is_punctuation = rePunctuation.test(char_before);
 
     left_flanking = !after_is_whitespace &&


### PR DESCRIPTION
The spec makes an distinction between "[whitespace]" and "[Unicode whitespace]": whereas the latter include many additional whitespace characters, particularly the non-breaking space (U+00A0), the former does not.

Per ECMA-262 6th Edition ("ECMAScript 2015") §21.2.2.12 [CharacterClassEscape], the JavaScript `\s` escape character matches the characters specified by "Unicode whitespace," but not "whitespace."

To fix this issue, rename the existing regular expression variable to `UnicodeWhitespace`, and create and use a new regular expression variable that only matches the limited set of "whitespace" characters.

The test suite does not yet cover this distinction. I will add a corresponding test case when this pull request has been accepted.

For additional information, the distinction in the spec was challenged and reaffirmed by jgm/CommonMark#343.

[whitespace]: http://spec.commonmark.org/0.26/#whitespace-character
[Unicode whitespace]: http://spec.commonmark.org/0.26/#unicode-whitespace-character
[CharacterClassEscape]: http://www.ecma-international.org/ecma-262/6.0/#sec-characterclassescape